### PR TITLE
Fixed an issue with /p:SolutionDir

### DIFF
--- a/lib/souyuz/generators/build_command_generator.rb
+++ b/lib/souyuz/generators/build_command_generator.rb
@@ -27,7 +27,7 @@ module Souyuz
         options << "/p:BuildIpa=true" if Souyuz.project.ios?
         if (config[:solution_path])
           solution_dir = File.dirname(config[:solution_path])
-          options << "/p:SolutionDir=#{solution_dir}"
+          options << "/p:SolutionDir=#{solution_dir}/"
         end
 
         options


### PR DESCRIPTION
Fixes an issue with trailing slashes not added to SolutionDir when building from command line, as Xamarin Studio validates and adds these slashes itself, while the xbuild CLI does not.

Original issue: #5