### PR TITLE
Updated highline dependency to support fastlane 2.182.0 and up

### DIFF
--- a/fastlane-plugin-souyuz/lib/fastlane/plugin/souyuz/version.rb
+++ b/fastlane-plugin-souyuz/lib/fastlane/plugin/souyuz/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Souyuz
-    VERSION = "0.10.4"
+    VERSION = "0.11.0"
   end
 end

--- a/lib/souyuz/version.rb
+++ b/lib/souyuz/version.rb
@@ -1,5 +1,5 @@
 
 module Souyuz
-  VERSION = "0.10.4"
+  VERSION = "0.11.0"
   DESCRIPTION = "A fastlane component to make Xamarin builds a breeze"
 end

--- a/souyuz.gemspec
+++ b/souyuz.gemspec
@@ -21,8 +21,8 @@ Gem::Specification.new do |s|
   s.test_files    = s.files.grep(%r{^(test|spec|features)/})
   s.require_paths = ["lib"]
 
-  s.add_dependency 'fastlane', '>= 1.103.0'
-  s.add_dependency 'highline', '~> 1.7'
+  s.add_dependency 'fastlane', '>= 2.182.0'
+  s.add_dependency 'highline', '~> 2.0'
   s.add_dependency 'nokogiri', '~> 1.7'
 
   # Development only


### PR DESCRIPTION
## The issue

Version 2.182.0 of Fastlane has updated the dependency on Highline to `~> 2.0`, making it impossible to install any version of the Soyuz Fastlane plugin newer than version 7.  I raised the issue #35 to track this.

## Changes
I've bumped the version dependency of highline to match that of fastlane version 2.182.0 onwards, the first version of fastlane to change from `highline  >= 1.7.2, < 2.0.0` to `highline  ~> 2.0`

## Testing
I've not thoroughly tested all the features of this plugin, however, I have built and tested the basic Souyuz build commands using local gems for both iOS and Android without observing any issues.  

Heads up, this is my first time doing anything with Ruby!