### PR TITLE
Add quotes around project and solution paths to fix error

### DIFF
--- a/fastlane-plugin-souyuz/lib/fastlane/plugin/souyuz/version.rb
+++ b/fastlane-plugin-souyuz/lib/fastlane/plugin/souyuz/version.rb
@@ -1,5 +1,5 @@
 module Fastlane
   module Souyuz
-    VERSION = "0.11.0"
+    VERSION = "0.11.1"
   end
 end

--- a/lib/souyuz/generators/build_command_generator.rb
+++ b/lib/souyuz/generators/build_command_generator.rb
@@ -31,7 +31,7 @@ module Souyuz
         options << "-p:BuildIpa=true" if Souyuz.project.ios?
         if config[:solution_path]
           solution_dir = File.dirname(config[:solution_path])
-          options << "-p:SolutionDir=#{solution_dir}/"
+          options << "-p:SolutionDir=\"#{solution_dir}/\""
         end
 
         options
@@ -52,7 +52,7 @@ module Souyuz
       def project
         path = []
 
-        path << Souyuz.config[:project_path] # if Souyuz.project.android?
+        path << "\"#{Souyuz.config[:project_path]}\"" # if Souyuz.project.android?
         # path << Souyuz.config[:solution_path] if Souyuz.project.ios? or Souyuz.project.osx?
 
         path

--- a/lib/souyuz/version.rb
+++ b/lib/souyuz/version.rb
@@ -1,5 +1,5 @@
 
 module Souyuz
-  VERSION = "0.11.0"
+  VERSION = "0.11.1"
   DESCRIPTION = "A fastlane component to make Xamarin builds a breeze"
 end


### PR DESCRIPTION
Fix for issue #37 .

Added quotes around project and solution paths in build_command_generator.rb.

Bumped version to 0.11.1.


Tested terminal output with space in path at 'projects/Fastlane Test/src' :
```
+---------------------+-------------------------------------------------------------------------------+
|                                      Summary for souyuz 0.11.1                                      |
+---------------------+-------------------------------------------------------------------------------+
| build_configuration | Release                                                                       |
| platform            | android                                                                       |
| build_platform      | AnyCPU                                                                        |
| solution_path       | /Users/duncan/projects/Fastlane Test/FastlaneTest.sln                         |
| project_name        | FastlaneTest.Droid                                                            |
| project_path        | /Users/duncan/projects/Fastlane                                               |
|                     | Test/src/FastlaneTest.Droid/FastlaneTest.Droid.csproj                         |
| output_path         | /Users/duncan/projects/Fastlane Test/src/FastlaneTest.Droid/bin/Release/      |
| manifest_path       | /Users/duncan/projects/Fastlane                                               |
|                     | Test/src/FastlaneTest.Droid/Properties/AndroidManifest.xml                    |
| buildtools_path     | /Users/duncan/Library/Developer/Xamarin/android-sdk-macosx/build-tools/30.0.2 |
| assembly_name       | com.<company>.fastlanetest                                                    |
| silent              | false                                                                         |
| compiler_bin        | msbuild                                                                       |
| build_target        | ["Build"]                                                                     |
| keystore_tsa        | http://timestamp.digicert.com                                                 |
+---------------------+-------------------------------------------------------------------------------+

[14:45:06]: $  msbuild -p:Configuration=Release -p:SolutionDir="/Users/duncan/projects/Fastlane Test/" -t:Build -t:SignAndroidPackage "/Users/duncan/projects/Fastlane Test/src/FastlaneTest.Droid/FastlaneTest.Droid.csproj"
[14:45:08]: ▸
Microsoft (R) Build Engine version 16.9.0 for Mono
[14:45:08]: ▸ Copyright (C) Microsoft Corporation. All rights reserved.
^[[64;15R[14:45:08]: ▸ Build started 09/02/2022 14:45:08.
```

